### PR TITLE
feat: add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/
 .env
 .env.production
 .dev.vars
+.envrc
 
 # logs
 logs/


### PR DESCRIPTION
## Summary
- Add .envrc to .gitignore to exclude direnv environment files from version control

## Test plan
- [x] Verify .envrc is properly ignored by git
- [x] Confirm existing env file patterns remain intact

🤖 Generated with [Claude Code](https://claude.ai/code)