### PR TITLE
noindexメタタグを削除して検索エンジンのインデックスを許可

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -32,7 +32,7 @@ export default jsxRenderer(({ children }) => {
 
         {/* その他のメタタグ */}
         <meta name="theme-color" content="#374151" />
-        <meta name="robots" content="noindex, nofollow" />
+        <meta name="robots" content="index, follow" />
         <link rel="canonical" href="https://senju.dev" />
 
         {/* ファビコン */}


### PR DESCRIPTION
## 概要
検索エンジンがサイトをインデックスできるように、robotsメタタグの設定を変更しました。

## 変更内容
- `app/routes/_renderer.tsx` のrobotsメタタグを以下のように変更:
  - 変更前: `<meta name="robots" content="noindex, nofollow" />`
  - 変更後: `<meta name="robots" content="index, follow" />`

## 変更理由
現在、サイトが検索エンジンにインデックスされないように設定されていますが、
コミュニティサイトとして公開されているため、検索エンジンからの流入を可能にするために
この変更を行いました。

## 影響範囲
- 検索エンジン（Google、Bing等）がサイトをクロールしてインデックスに登録できるようになります
- 検索結果にサイトが表示されるようになります

🤖 Generated with [Claude Code](https://claude.ai/code)