### PR TITLE
feat: add Buy Me a Coffee link to header

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { DiscordIcon, ConnpassIcon } from "./icons";
+import { DiscordIcon, ConnpassIcon, BuyMeCoffeeIcon } from "./icons";
 
 export function Navigation() {
   return (
@@ -38,6 +38,15 @@ export function Navigation() {
         >
           <ConnpassIcon className="w-5 h-5" />
           <span class="hidden sm:inline">connpass</span>
+        </a>
+        <a
+          href="https://buymeacoffee.com/senjudev"
+          class="text-gray-700 hover:text-gray-900 font-medium transition-colors flex items-center gap-2"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <BuyMeCoffeeIcon className="w-5 h-5" />
+          <span class="hidden sm:inline">Support</span>
         </a>
       </div>
     </nav>

--- a/app/components/icons.tsx
+++ b/app/components/icons.tsx
@@ -16,14 +16,29 @@ export function DiscordIcon({ className = "w-5 h-5" }: { className?: string }) {
 // Connpass SVG Icon (simplified calendar/event icon)
 export function ConnpassIcon({ className = "w-5 h-5" }: { className?: string }) {
   return (
-    <svg 
-      className={className} 
-      viewBox="0 0 24 24" 
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
       fill="currentColor"
       role="img"
       aria-label="connpass"
     >
       <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/>
+    </svg>
+  );
+}
+
+// Buy Me a Coffee SVG Icon
+export function BuyMeCoffeeIcon({ className = "w-5 h-5" }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      role="img"
+      aria-label="Buy Me a Coffee"
+    >
+      <path d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.89 2-2V5c0-1.11-.89-2-2-2zm0 5h-2V5h2v3zM4 19h16v2H4z"/>
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- ヘッダーに Buy Me a Coffee のサポートリンクを追加
- コーヒーカップアイコンと「Support」ラベルを表示
- リンク先: https://buymeacoffee.com/senjudev

## Changes
- `app/components/icons.tsx`: `BuyMeCoffeeIcon` コンポーネントを追加
- `app/components/Navigation.tsx`: ヘッダーナビゲーションに Support リンクを追加

## Test plan
- [x] 開発サーバーでヘッダーにリンクが表示されることを確認
- [ ] デスクトップ表示: アイコン + 「Support」テキストが表示される
- [ ] モバイル表示: アイコンのみが表示される
- [ ] リンクが正しく https://buymeacoffee.com/senjudev に遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)